### PR TITLE
Add script to build rpm packages

### DIFF
--- a/rpm/REAMDE.md
+++ b/rpm/REAMDE.md
@@ -2,8 +2,6 @@
 
 To build an rpm package, run the following command from the core of the repository.
 
-**NOTE**: Don't forget to update the version number in the specification file!
-
 ```
 $ ./rpm/build.sh
 ```

--- a/rpm/REAMDE.md
+++ b/rpm/REAMDE.md
@@ -1,0 +1,10 @@
+# Building the RPM package
+
+To build an rpm package, run the following command from the core of the repository.
+
+**NOTE**: Don't forget to update the version number in the specification file!
+
+```
+$ ./rpm/build.sh
+```
+

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -23,9 +23,6 @@ if [[ ${UID} -eq 0 ]]; then
    exit 1
 fi
 
-# Install the necessary packages when needed.
-command -v rpmdev-setuptree &> /dev/null || sudo dnf install rpm-build rpmdevtools
-
 # Create the necessary directories.
 mkdir -p "${HOME}/rpmbuild/"{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 mkdir -p "${HOME}/rpmbuild/BUILD/${NAME}-${VERSION}"

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script will package the `update` script into a `rpm` package.
+
+declare -r NAME="update"
+declare -r BUILD_DIR="$(pwd)"
+declare -r VERSION="$(grep "version=" "${BUILD_DIR}/${NAME}" | cut -d"\"" -f2 | cut -d"v" -f2)"
+# declare -r VERSION="1.4.2"
+
+# Exit out when running the script as root.
+if [[ ${UID} -eq 0 ]]; then
+   printf 'Please run this script as a normal user.'
+   exit 1
+fi
+
+# Install the necessary packages when needed.
+command -v rpmdev-setuptree &> /dev/null || sudo dnf install rpm-build rpmdevtools
+
+# Create the necessary directories.
+mkdir -p "${HOME}/rpmbuild/"{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+mkdir -p "${HOME}/rpmbuild/BUILD/${NAME}-${VERSION}"
+mkdir -p "${BUILD_DIR}/${NAME}-${VERSION}"
+
+# Create the tarball.
+cp -r "${BUILD_DIR}/${NAME}" "${BUILD_DIR}/${NAME}-${VERSION}"
+tar --create --file "${NAME}-${VERSION}.tar.gz" "${NAME}-${VERSION}"
+
+# Move the tarball to the SOURCES directory.
+mv "${BUILD_DIR}/${NAME}-${VERSION}.tar.gz" "${HOME}/rpmbuild/SOURCES/"
+
+# Copy over the spec file.
+sed -i "s/VERSION THE SCRIPT WILL UPDATE THIS!/${VERSION}/g" "${BUILD_DIR}/rpm/${NAME}.spec"
+cp -r "${BUILD_DIR}/rpm/${NAME}.spec" "${HOME}/rpmbuild/SPECS/${NAME}.spec"
+
+# build RPM package.
+rpmbuild -ba "${HOME}/rpmbuild/SPECS/${NAME}.spec"
+
+# Cleanup
+rm -rf "${NAME}-${VERSION}"
+

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -6,6 +6,17 @@ declare -r NAME="update"
 declare -r BUILD_DIR="$(pwd)"
 declare -r VERSION="$(grep "version=" "${BUILD_DIR}/${NAME}" | cut -d"\"" -f2 | cut -d"v" -f2)"
 
+if command -v dnf &>/dev/null; then
+   command -v rpmdev-setuptree &> /dev/null && command -v rpmbuild &>/dev/null || sudo dnf install rpm-build rpmdevtools -y
+elif command -v yum &>/dev/null; then
+   command -v rpmdev-setuptree &> /dev/null && command -v rpmbuild &>/dev/null || sudo yum install rpm-build rpmdevtools -y
+elif command -v apt &>/dev/null; then
+   command -v rpmbuild &>/dev/null || sudo apt install rpm -y
+else
+   printf 'No suitable package manager found!! Exiting...'
+   exit 1
+fi
+
 # Exit out when running the script as root.
 if [[ ${UID} -eq 0 ]]; then
    printf 'Please run this script as a normal user.'

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -5,7 +5,6 @@
 declare -r NAME="update"
 declare -r BUILD_DIR="$(pwd)"
 declare -r VERSION="$(grep "version=" "${BUILD_DIR}/${NAME}" | cut -d"\"" -f2 | cut -d"v" -f2)"
-# declare -r VERSION="1.4.2"
 
 # Exit out when running the script as root.
 if [[ ${UID} -eq 0 ]]; then
@@ -28,8 +27,10 @@ tar --create --file "${NAME}-${VERSION}.tar.gz" "${NAME}-${VERSION}"
 # Move the tarball to the SOURCES directory.
 mv "${BUILD_DIR}/${NAME}-${VERSION}.tar.gz" "${HOME}/rpmbuild/SOURCES/"
 
-# Copy over the spec file.
+# Update the version number.
 sed -i "s/VERSION THE SCRIPT WILL UPDATE THIS!/${VERSION}/g" "${BUILD_DIR}/rpm/${NAME}.spec"
+
+# Copy over the spec file.
 cp -r "${BUILD_DIR}/rpm/${NAME}.spec" "${HOME}/rpmbuild/SPECS/${NAME}.spec"
 
 # build RPM package.

--- a/rpm/update.spec
+++ b/rpm/update.spec
@@ -1,0 +1,29 @@
+Name:           update
+Version:        VERSION THE SCRIPT WILL UPDATE THIS!
+Release:        1%{?dist}
+BuildArch:      noarch
+URL:            https://github.com/Crilum/%{name}
+Summary:        Updates apps/packages/dependencies from Apt, Pi-Apps, Flatpak, the Snap Store, Homebrew, and NPM.
+
+License:        GPLv3
+Source0:        %{name}-%{version}.tar.gz
+
+Requires: bash
+
+%description
+Updates apps/packages/dependencies from Apt, Pi-Apps, Flatpak, the Snap Store, Homebrew, and NPM.
+
+%prep
+%setup -q
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_bindir}
+cp %{name} $RPM_BUILD_ROOT/%{_bindir}
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%{_bindir}/%{name}
+


### PR DESCRIPTION
As suggested in https://github.com/Crilum/update/issues/16 I wrote a script to create rpm packages. This script ensures that programs such as `alien` are no longer needed in the future.

The script creates the necessary files/folders, updates and move the files to their corresponding folder and finally builds a rpm package that can be used on any cpu architecture.

To build an rpm package one has to run the following command from the core of the repository. I've added a small README file with the build instruction just in case.

```
$ ./rpm/build.sh
```

The script seems to work fine on my machine although **I recommend testing it before merging**.

This PR should close https://github.com/Crilum/update/issues/16.
