### PR TITLE
Better way of symlinking `up` to `update` (rpm)

### DIFF
--- a/install
+++ b/install
@@ -109,14 +109,10 @@ Linux)
     if command -v update &>/dev/null; then
       printf "\n${WHITE}Uninstalling update...${NC}"
       $sudo $pkg_manager remove -y update
-      echo -e "${WHITE}Removing \`${LICYAN}up${WHITE}\` command... (If you have a \`/usr/bin/up\` file that you care about, you might want to copy it somewhere safe!)\n\nWaiting 10 seconds...${NC}"
-      sudo rm -f /usr/bin/up
       printf "\n${GREEN}Done!${NC}"
     fi
     printf "\n${WHITE}Installing update...${NC}"
     $sudo $pkg_manager install ./update-${LATEST}-1.noarch.rpm -y
-    $sudo chmod +x /usr/bin/update
-    $sudo chmod +x /usr/bin/up
     printf "\n${GREEN}Done!${NC}\n"
     rm update-${LATEST}-1.noarch.rpm
     ;;

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -33,8 +33,6 @@ mkdir -p "${BUILD_DIR}/${NAME}-${VERSION}"
 # Create the tarball.
 echo "Creating tarball..."
 cp -r "${BUILD_DIR}/${NAME}" "${BUILD_DIR}/${NAME}-${VERSION}"
-echo "Linking update to up..."
-ln -v -s /usr/bin/update "${BUILD_DIR}/${NAME}-${VERSION}/up" || echo "failed to link update to up!"
 echo "Done!"; ls "${BUILD_DIR}/${NAME}-${VERSION}/"
 tar --create --file "${NAME}-${VERSION}.tar.gz" "${NAME}-${VERSION}"
 

--- a/rpm/update.spec
+++ b/rpm/update.spec
@@ -22,12 +22,17 @@ Updates apps/packages/dependencies from Apt, Pi-Apps, Flatpak, the Snap Store, H
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 cp %{name} $RPM_BUILD_ROOT/%{_bindir}
-cp up $RPM_BUILD_ROOT/%{_bindir}
 
+%post
+[[ -L %{_bindir}/up ]] && rm -rf %{_bindir}/up
+ln -v -s %{_bindir}/update %{_bindir}/up
+
+%postun
+[[ -L %{_bindir}/up ]] && rm -rf %{_bindir}/up
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files
 %{_bindir}/%{name}
-%{_bindir}/up
+


### PR DESCRIPTION
Rpm-packages have a `%preun` stage this stage contains the commands that are run after uninstalling the package. This is something similar the `postrm` file for deb-packages.

This allows you to let the package manager remove the symlink, this makes it so you don't have to write extra code to remove it inside the `install` script.

You can find more information about it here https://www.golinuxhub.com/2018/05/how-to-execute-script-at-pre-post-preun-postun-spec-file-rpm/.
