### PR TITLE
Better way of checking if the symlink `up` to `update` exists (deb)

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ "$(file /usr/bin/up)" =~ "symbolic link to /usr/bin/update" ]]; then
+if [[ -L "/usr/bin/up" ]]; then
   rm -rf /usr/bin/up
 else
   echo "It looks like your '/usr/bin/up' file isn't a symbolic link to '/usr/bin/update', so it hasn't been removed. If you stil want to remove it, you can do so with: sudo rm -f /usr/bin/up"

--- a/update
+++ b/update
@@ -87,7 +87,7 @@ function status() {
 function internet_check() {
     if ! command -v wget &>/dev/null; then
         error "\`wget\` isn't installed! wget is required to perform connection tests. Please install wget."
-    if ! wget --spider "https://github.com" &>/dev/null; then
+    elif ! wget --spider "https://github.com" &>/dev/null; then
         error "I tried to contact ${BLUE}${BOLD}https://github.com${LIRED} but it did not respond! Check your internet connection!"
     fi
 }


### PR DESCRIPTION
It's better to use the `-L` flag inside the if-statement instead of `$(file path/to/symlink)`.

I've also fixed a small syntax error inside the update script.